### PR TITLE
bau: Remove carriage returns from certificates

### DIFF
--- a/app/models/config_file_service.rb
+++ b/app/models/config_file_service.rb
@@ -66,7 +66,11 @@ class ConfigFileService
   private
 
   def format_certificate(certificate)
-    certificate.gsub("\n",'').gsub('-----BEGIN CERTIFICATE-----','').gsub('-----END CERTIFICATE-----','')
+    certificate
+      .gsub("\n",'')
+      .gsub("\r",'')
+      .gsub('-----BEGIN CERTIFICATE-----','')
+      .gsub('-----END CERTIFICATE-----','')
   end
 
 end


### PR DESCRIPTION
On windows newlines are represented as \r\n instead of just \n like they
are on Linux and macOs systems. Previously we'd end up with a bunch of
\r characters in the generated config files.