### PR TITLE
bau: Remove IP address questions - we don't need these anymore :tada:

### DIFF
--- a/app/assets/javascripts/environment_config_form.js
+++ b/app/assets/javascripts/environment_config_form.js
@@ -1,11 +1,9 @@
 function toggleHideableFields() {
     if ($('#onboarding_form_environment_access_production-access-request').is(':checked')) {
         $('.stub-api-details').hide().find('input').removeAttr('required').val('');
-        $('#testing_devices_ips').val('').removeAttr('required').parent().hide()
     }
     if ($('#onboarding_form_environment_access_integration-access-request').is(':checked')) {
         $('.stub-api-details').show().find('input').attr('required', true);
-        $('#testing_devices_ips').attr('required', true).parent().show()
     }
 }
 $('[name="onboarding_form\[environment_access\]"]').change(toggleHideableFields)

--- a/app/models/onboarding_form.rb
+++ b/app/models/onboarding_form.rb
@@ -22,8 +22,7 @@ class OnboardingForm
     :contact_details_phone,
     :contact_details_message,
     :stub_idp_username,
-    :stub_idp_password,
-    :testing_devices_ips
+    :stub_idp_password
   ]
 
   REQUIRED_FIELDS = [
@@ -44,7 +43,6 @@ class OnboardingForm
     :contact_details_email,
     :contact_details_service,
     :contact_details_department,
-    :matching_service_adapter_ip
   ]
 
   URL_FIELDS = [
@@ -71,7 +69,6 @@ class OnboardingForm
 
   validates :stub_idp_username, presence: true, if: :is_integration_access_form?
   validates :stub_idp_password, presence: true, length: { minimum: 8 }, if: :is_integration_access_form?
-  validates :testing_devices_ips, presence: true, if: :is_integration_access_form?
   validates :contact_details_email, format: { with: /.+@.+/, message: 'is not properly formatted' }
   validate :validate_entity_ids_are_different, :validate_certificate
 

--- a/app/models/onboarding_form_service.rb
+++ b/app/models/onboarding_form_service.rb
@@ -65,12 +65,6 @@ class OnboardingFormService
                 Matching service user account creation URL:
                 #{ value_or_default(onboarding_form.user_account_creation_uri) }
 
-                IP address of devices used for testing:
-                #{ value_or_default(onboarding_form.testing_devices_ips) }
-
-                Matching Service Adapter IP address:
-                #{ value_or_default(onboarding_form.matching_service_adapter_ip) }
-
                 Transaction signature verification certificate:
                 #{ value_or_default(onboarding_form.signature_verification_certificate_transaction) }
 

--- a/app/views/environment_config_form/environment_config_form.html.erb
+++ b/app/views/environment_config_form/environment_config_form.html.erb
@@ -109,8 +109,7 @@
                input_type: 'url',
                information: '<p>Tell us which URL you will use to receive your Verify matching service requests, for example:</p>
                <p>Integration: <code>https://{your-integration-domain}/matching-service/POST</code></p>
-               <p>Production: <code>https://{your-production-domain}.gov.uk/matching-service/POST</code></p>
-               <p>To maintain security, GOV.UK Verify servers only communicate with whitelisted IP addresses.</p>'
+               <p>Production: <code>https://{your-production-domain}.gov.uk/matching-service/POST</code></p>'
     %>
     <%= render 'question',
                value: @onboarding_form.user_account_creation_uri,
@@ -127,43 +126,6 @@
                <p>You only need to do this if you have user account creation enabled for your service.</p>
                '
     %>
-    <h2 class="heading-medium">IP addresses</h2>
-    <p>
-      To ensure correct message exchange, between your service and GOV.UK Verify, we need to know which IP
-      addresses you will use for:
-    </p>
-
-    <%= render 'question',
-               value: @onboarding_form.testing_devices_ips,
-               errors: @onboarding_form.errors['testing_devices_ips'],
-               title: 'Test device browser IP addresses',
-               id: 'testing_devices_ips',
-               input_type: 'text',
-               information: '
-               <p>Within the Integration environment, Verify webpages are only visible to whitelisted IP addresses.
-               The Production environment is open access.</p>
-               <p>Your IP addresses should be either:
-               <ul class="list-bullet">
-               <li>static, or</li>
-               <li>fall within a narrow address range</li>
-               </ul>
-               </p>
-               <p>
-               Enter the browser IP addresses you will use to access the GOV.UK Verify Integration environment,
-               for example:  <code>10.1.2.3,10.1.2.4</code> or <code>10.39.34.15/30</code>.
-               </p>
-               <p>If more than one address, please enter as a comma separated list.</p>
-               '
-    %>
-    <%= render 'question',
-               value: @onboarding_form.matching_service_adapter_ip,
-               errors: @onboarding_form.errors['matching_service_adapter_ip'],
-               title: 'Matching Service Adapter IP address',
-               id: 'matching_service_adapter_ip',
-               input_type: 'text',
-               information: '<p>The IP address of the domain that will host your Matching Service Adapter</p>'
-    %>
-
     <h2 class="heading-medium">Verify user webpage texts</h2>
     <p>
       Specific signposting webpages are displayed during the user’s journey.

--- a/spec/features/user_visits_form_spec.rb
+++ b/spec/features/user_visits_form_spec.rb
@@ -98,8 +98,6 @@ RSpec.describe 'The start page', :type => :feature do
     fill_in 'Matching service encryption certificate', with: GOOD_CERT_GOOD_ISSUER_INTEGRATION
 
     fill_in 'Matching Service Adapter: User account creation URL', with: 'http://example.com/msa/create-account'
-    fill_in 'Matching Service Adapter IP address', with: 'some IP address'
-    fill_in 'Test device browser IP addresses', with: 'some IP address'
     fill_in 'Verify service display name', with: 'something'
     fill_in 'Other ways to apply display name', with: 'something'
     fill_in 'Other ways to complete the transaction', with: 'something'

--- a/spec/models/config_file_service_spec.rb
+++ b/spec/models/config_file_service_spec.rb
@@ -11,8 +11,6 @@ describe 'ConfigFileService' do
     service_homepage_url: 'https://example.com/start',
     assertion_consumer_services_https_url: 'https://example.com/process-response',
     cycle3_attribute_name: 'cycle3attr',
-    testing_devices_ips: 'some-ip-address',
-    matching_service_adapter_ip: 'some-ip-address',
     signature_verification_certificate_transaction: GOOD_CERT_GOOD_ISSUER_INTEGRATION,
     signature_verification_certificate_match: GOOD_CERT_GOOD_ISSUER_INTEGRATION,
     encryption_certificate_transaction: GOOD_CERT_GOOD_ISSUER_INTEGRATION,

--- a/spec/models/onboarding_form_service_spec.rb
+++ b/spec/models/onboarding_form_service_spec.rb
@@ -12,8 +12,6 @@ describe OnboardingFormService do
         service_homepage_url: 'https://example.com/start',
         assertion_consumer_services_https_url: 'https://example.com/process-response',
         cycle3_attribute_name: 'cycle3attr',
-        testing_devices_ips: 'some-ip-address',
-        matching_service_adapter_ip: 'some-ip-address',
         signature_verification_certificate_transaction: GOOD_CERT_GOOD_ISSUER_INTEGRATION,
         signature_verification_certificate_match: GOOD_CERT_GOOD_ISSUER_INTEGRATION,
         encryption_certificate_transaction: GOOD_CERT_GOOD_ISSUER_INTEGRATION,
@@ -79,12 +77,6 @@ describe OnboardingFormService do
                 Matching service user account creation URL:
                 https://example.com
 
-                IP address of devices used for testing:
-                some-ip-address
-
-                Matching Service Adapter IP address:
-                some-ip-address
-
                 Transaction signature verification certificate:
                 #{GOOD_CERT_GOOD_ISSUER_INTEGRATION}
 
@@ -148,8 +140,6 @@ describe OnboardingFormService do
           service_homepage_url: '',
           assertion_consumer_services_https_url: '',
           cycle3_attribute_name: '',
-          testing_devices_ips: '',
-          matching_service_adapter_ip: '',
           signature_verification_certificate_transaction: '',
           signature_verification_certificate_match: '',
           encryption_certificate_transaction: '',
@@ -205,12 +195,6 @@ describe OnboardingFormService do
                 -
 
                 Matching service user account creation URL:
-                -
-
-                IP address of devices used for testing:
-                -
-
-                Matching Service Adapter IP address:
                 -
 
                 Transaction signature verification certificate:

--- a/spec/models/onboarding_form_spec.rb
+++ b/spec/models/onboarding_form_spec.rb
@@ -11,8 +11,6 @@ describe OnboardingForm do
           :service_entity_id => 'http://example.com',
           :matching_service_entity_id => 'http://example.com/msa',
           :matching_service_url => 'http://example.com/msa',
-          :matching_service_adapter_ip => 'something',
-          :testing_devices_ips => 'something',
           :service_homepage_url => 'http://example.com',
           :assertion_consumer_services_https_url => 'http://example.com',
           :signature_verification_certificate_transaction => GOOD_CERT_GOOD_ISSUER_INTEGRATION,
@@ -39,8 +37,6 @@ describe OnboardingForm do
       expect(form.errors['service_entity_id']).to include("can't be blank")
       expect(form.errors['matching_service_entity_id']).to include("can't be blank")
       expect(form.errors['matching_service_url']).to include("can't be blank")
-      expect(form.errors['matching_service_adapter_ip']).to include("can't be blank")
-      expect(form.errors['testing_devices_ips']).to include("can't be blank")
       expect(form.errors['service_homepage_url']).to include("can't be blank")
       expect(form.errors['assertion_consumer_services_https_url']).to include("can't be blank")
       expect(form.errors['signature_verification_certificate_transaction']).to include("can't be blank")


### PR DESCRIPTION
Now that we've removed the integration environment firewall and the
stub-idp firewall (by moving it to PaaS) people don't need to tell us
their IP addresses. This means we can remove them from the form.