### PR TITLE
ZD48213 - update connecting form to use new name for Zendesk group

### DIFF
--- a/app/models/onboarding_form_service.rb
+++ b/app/models/onboarding_form_service.rb
@@ -28,7 +28,7 @@ class OnboardingFormService
     end
 
     def find_group_id()
-      ZENDESK_CLIENT.search({:query => "type:group name:'Connecting to Verify'"}).fetch.first.id
+      ZENDESK_CLIENT.search({:query => "type:group name:'#{ZENDESK_GROUP_NAME}'"}).fetch.first.id
     end
 
     def generate_ticket_body(onboarding_form)

--- a/config/initializers/zendesk_client.rb
+++ b/config/initializers/zendesk_client.rb
@@ -5,3 +5,5 @@ ZENDESK_CLIENT = ZendeskAPI::Client.new do |config|
   config.username = ENV.fetch('ZENDESK_USERNAME')
   config.token = ENV.fetch('ZENDESK_TOKEN')
 end
+
+ZENDESK_GROUP_NAME = '3rd Line - Connecting to Verify'

--- a/spec/features/user_visits_form_spec.rb
+++ b/spec/features/user_visits_form_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'The start page', :type => :feature do
 
   ZENDESK_TICKETS_URL = "#{ENV.fetch('ZENDESK_BASE_URL')}tickets"
   ZENDESK_UPLOADS_URL = "#{ENV.fetch('ZENDESK_BASE_URL')}uploads"
-  ZENDESK_SEARCH_URL = "#{ENV.fetch('ZENDESK_BASE_URL')}search?query=type:group name:'Connecting to Verify'"
+  ZENDESK_SEARCH_URL = "#{ENV.fetch('ZENDESK_BASE_URL')}search?query=type:group name:'#{ZENDESK_GROUP_NAME}'"
 
   before(:all) do
     @cert_file = Tempfile.new('good-cert')


### PR DESCRIPTION
Form was erroring for production submit due to old name for zendesk group

Co-Authored-By: Steve Butler <steve.butler@digital.cabinet-office.gov.uk>