### PR TITLE
Make configs private

### DIFF
--- a/app/models/onboarding_form_service.rb
+++ b/app/models/onboarding_form_service.rb
@@ -9,11 +9,17 @@ class OnboardingFormService
 
     def upload_config_files(ticket, config_files)
       # if the ticket's body isn't overwritten, the entire form is re-posted
-      ticket.comment.body = 'automatically generated config files:'
+      comment = ZendeskAPI::Ticket::Comment.new(ZENDESK_CLIENT, {
+          body: 'Automatically generated config files:',
+          public: false
+      })
 
       config_files.each do |file|
-        ticket.comment.uploads << file
+        comment.uploads << file
       end
+
+      comment.save!
+      ticket.update(comment: comment)
       ticket.save!
     end
 

--- a/spec/models/onboarding_form_service_spec.rb
+++ b/spec/models/onboarding_form_service_spec.rb
@@ -41,7 +41,7 @@ describe OnboardingFormService do
   context 'prepare the zendesk ticket' do
 
     it 'should generate a valid zendesk ticket' do
-      json = JSON.dump({"results": [{ "name": "Connecting to Verify", "created_at":  "2009-05-13T00:07:08Z", "updated_at": "2011-07-22T00:11:12Z", "id": 360000257114, "result_type": "group", "url": "http://example.com" }], "count": 1})
+      json = {"results": [{ "name": "Connecting to Verify", "created_at":  "2009-05-13T00:07:08Z", "updated_at": "2011-07-22T00:11:12Z", "id": 360000257114, "result_type": "group", "url": "http://example.com" }], "count": 1}.to_json
       stub_request(:get, "https://example.com/api/v2/search?query=type:group%20name:'Connecting%20to%20Verify'")
           .with(:headers => {'Accept'=>'application/json'})
           .to_return(:status => 200, :body => json, :headers => { :content_type => "application/json", :content_length => json.size })
@@ -136,7 +136,7 @@ describe OnboardingFormService do
     end
 
     it 'should generate an empty zendesk ticket' do
-      json = JSON.dump({"results": [{ "name": "Connecting to Verify", "created_at":  "2009-05-13T00:07:08Z", "updated_at": "2011-07-22T00:11:12Z", "id": 360000257114, "result_type": "group", "url": "http://example.com" }], "count": 1})
+      json = {"results": [{ "name": "Connecting to Verify", "created_at":  "2009-05-13T00:07:08Z", "updated_at": "2011-07-22T00:11:12Z", "id": 360000257114, "result_type": "group", "url": "http://example.com" }], "count": 1}.to_json
       stub_request(:get, "https://example.com/api/v2/search?query=type:group%20name:'Connecting%20to%20Verify'")
           .with(:headers => {'Accept'=>'application/json'})
           .to_return(:status => 200, :body => json, :headers => { :content_type => "application/json", :content_length => json.size })

--- a/spec/models/onboarding_form_service_spec.rb
+++ b/spec/models/onboarding_form_service_spec.rb
@@ -41,6 +41,10 @@ describe OnboardingFormService do
   context 'prepare the zendesk ticket' do
 
     it 'should generate a valid zendesk ticket' do
+      json = JSON.dump({"results": [{ "name": "Connecting to Verify", "created_at":  "2009-05-13T00:07:08Z", "updated_at": "2011-07-22T00:11:12Z", "id": 360000257114, "result_type": "group", "url": "http://example.com" }], "count": 1})
+      stub_request(:get, "https://example.com/api/v2/search?query=type:group%20name:'Connecting%20to%20Verify'")
+          .with(:headers => {'Accept'=>'application/json'})
+          .to_return(:status => 200, :body => json, :headers => { :content_type => "application/json", :content_length => json.size })
 
       form = create_valid_form
 
@@ -132,6 +136,11 @@ describe OnboardingFormService do
     end
 
     it 'should generate an empty zendesk ticket' do
+      json = JSON.dump({"results": [{ "name": "Connecting to Verify", "created_at":  "2009-05-13T00:07:08Z", "updated_at": "2011-07-22T00:11:12Z", "id": 360000257114, "result_type": "group", "url": "http://example.com" }], "count": 1})
+      stub_request(:get, "https://example.com/api/v2/search?query=type:group%20name:'Connecting%20to%20Verify'")
+          .with(:headers => {'Accept'=>'application/json'})
+          .to_return(:status => 200, :body => json, :headers => { :content_type => "application/json", :content_length => json.size })
+
       form = OnboardingForm.new({
           environment_access: '',
           service_entity_id: '',
@@ -164,6 +173,7 @@ describe OnboardingFormService do
           stub_idp_username: '',
           stub_idp_password: ''
       })
+
       expect(OnboardingFormService.generate_ticket_body(form)).to eq({
           requester: {
               name: '-',


### PR DESCRIPTION
This PR adds a new comment to the created Zendesk ticket specifically for the generated configuration files. This is marked as `private`, which creates the note as an _internal note_, which is not seen by the requesting user.

Co-authored-by: Rosa Fox <rosa.fox@digital.cabinet-office.gov.uk>