### PR TITLE
End to End smoke test of config form submission

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ruby:2.3.1
+
+# Needed for rspec
+RUN apt-get update && apt-get install -y nodejs
+
+COPY Gemfile Gemfile
+COPY Gemfile.lock Gemfile.lock
+
+RUN bundle install
+
+WORKDIR /app
+
+ENTRYPOINT ["bundle", "exec", "rspec", "--tag", "smoke"]

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,8 @@ gem 'bcrypt', '3.1.11'
 
 gem 'zendesk_api', '1.15.0'
 
+gem 'selenium-webdriver'
+
 group :development, :test do
   gem 'rspec', '~> 3.5.0'
   gem 'rspec-rails', '~> 3.5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,8 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    childprocess (0.7.1)
+      ffi (~> 1.0, >= 1.0.11)
     concurrent-ruby (1.0.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
@@ -160,6 +162,7 @@ GEM
       rspec-mocks (~> 3.5.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
+    rubyzip (1.2.1)
     safe_yaml (1.0.4)
     sass (3.4.23)
     sass-rails (5.0.6)
@@ -168,6 +171,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    selenium-webdriver (3.4.4)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.0)
     spring (2.0.1)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)
@@ -228,6 +234,7 @@ DEPENDENCIES
   rspec (~> 3.5.0)
   rspec-rails (~> 3.5.0)
   sass-rails (~> 5.0)
+  selenium-webdriver
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data

--- a/README.md
+++ b/README.md
@@ -26,3 +26,12 @@ open localhost:3000
 
 `./pre-commit.sh`
 
+## Running the smoke test
+
+`user_visits_form_smoke_spec.rb` will run an end to end acceptance test, creating a real ticket in Zendesk when this test submits the config form.
+
+The test is run within Docker. This allows us to create an environment that includes the dependencies required by Selenium to run on our Jenkins setup. The Jenkins job that runs the smoke test occurs every time a change is pushed to this git repository.
+
+The smoke test has been filtered out of the main test run (`bundle exec rspec spec`) via a `smoke` filter.
+
+To run the smoke test, use: `./smoke-test.sh`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3'
+
+services:
+  selenium-hub:
+    image: selenium/standalone-firefox
+
+  spec-tester:
+    build: .

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+set -eu #quits script on error
+
+trap 'docker-compose down' EXIT
+
+docker-compose build spec-tester
+docker-compose up -d selenium-hub
+docker-compose run -v $(pwd):/app:ro spec-tester spec/features/user_visits_form_smoke_spec.rb

--- a/spec/features/user_visits_form_smoke_spec.rb
+++ b/spec/features/user_visits_form_smoke_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+require 'tempfile'
+
+RSpec.describe 'The start page', :type => :feature, :smoke => true do
+  before(:all) do
+    @cert_file = Tempfile.new('good-cert')
+    @cert_file.write(GOOD_CERT_GOOD_ISSUER_INTEGRATION)
+    @cert_file.close
+  end
+
+  after(:all) do
+    @cert_file.unlink
+  end
+
+  # Instructions for running this spec have been documented in the README.
+  it 'should submit form with real requests', :js => true do
+    WebMock.allow_net_connect!
+
+    submit_valid_form
+
+    expect(page).to have_content('Your request has been submitted')
+    expect(page).to have_content('Your ticket has been created')
+    expect(current_path).to eq '/submit'
+  end
+
+
+  def submit_valid_form
+    visit 'https://verify-environment-access.cloudapps.digital/'
+
+    fill_in('Verify service entity ID', with: 'http://smoketestexample.com')
+    fill_in('Matching Service Adapter entity ID', with: 'http://smoketestexample.com/msa')
+    fill_in('Matching Service Adapter: matching URL', with: 'http://smoketestexample.com/msa')
+    fill_in('Service start page URL', with: 'http://smoketestexample.com')
+    fill_in('Verify SAML response URL', with: 'http://smoketestexample.com')
+
+    fill_in 'Service signature validation certificate', with: GOOD_CERT_GOOD_ISSUER_INTEGRATION
+    fill_in 'Matching service signature validation certificate', with: GOOD_CERT_GOOD_ISSUER_INTEGRATION
+    fill_in 'Service encryption certificate', with: GOOD_CERT_GOOD_ISSUER_INTEGRATION
+    fill_in 'Matching service encryption certificate', with: GOOD_CERT_GOOD_ISSUER_INTEGRATION
+
+    fill_in 'Matching Service Adapter: User account creation URL', with: 'http://example.com/msa/create-account'
+    fill_in 'Verify service display name', with: 'smoke test'
+    fill_in 'Other ways to apply display name', with: 'smoke test'
+    fill_in 'Other ways to complete the transaction', with: 'smoke test'
+
+    fill_in 'Username', with: 'smoketest'
+    fill_in 'Password', with: 'password'
+
+    fill_in 'Name', with: 'smoketest'
+    fill_in 'Email address', with: 'email@example.com'
+    fill_in 'Service', with: 'smoketest'
+    fill_in 'Department or Agency', with: 'smoketest'
+
+    click_button 'Request access'
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,6 +10,14 @@ require 'spec_helper'
 require 'rspec/rails'
 
 RSpec.configure do |config|
+  config.run_all_when_everything_filtered = true
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
+  config.filter_run_excluding :smoke => true
+  if config.filter_manager.inclusions[:smoke]
+    Capybara.javascript_driver = :selenium_remote_firefox
+    Capybara.register_driver "selenium_remote_firefox".to_sym do |app|
+      Capybara::Selenium::Driver.new(app, browser: :remote, url: "http://selenium-hub:4444/wd/hub", desired_capabilities: :firefox)
+    end
+  end
 end


### PR DESCRIPTION
- `user_visits_form_smoke_spec.rb` will run an end to end acceptance test, creating a real ticket in Zendesk when this test submits the config form.

- The test is run within Docker. This allows us to create an environment that includes the dependencies required by selenium to be run on Jenkins.

- The smoke test is run periodically via a Jenkins job. It has been filtered out of the main test run (`bundle exec rspec spec`) via a `smoke` filter.

Co-authored-by: @NasAshrafThoughtworks @andy-paine @robinmitra 