### PR TITLE
PMI449: update zendesk's group name (ZD64382)

### DIFF
--- a/config/initializers/zendesk_client.rb
+++ b/config/initializers/zendesk_client.rb
@@ -6,4 +6,4 @@ ZENDESK_CLIENT = ZendeskAPI::Client.new do |config|
   config.token = ENV.fetch('ZENDESK_TOKEN')
 end
 
-ZENDESK_GROUP_NAME = '3rd Line - Connecting to Verify'
+ZENDESK_GROUP_NAME = '3rd Line - Product Support (all teams)'


### PR DESCRIPTION
- updated hardcoded ZENDESK_GROUP_NAME to '3rd Line - Product Support
(all teams)'

Co-Authored-By: Donna Belsey <donna.belsey@digital.cabinet-office.gov.uk>