### PR TITLE
Revert Zendesk group ID as environment variable and doc improvements

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,3 +1,11 @@
+# Base URL of Zendesk API (e.g. https://<your-org>.zendesk.com/api/v2/).
 ZENDESK_BASE_URL='example.com'
+
+# Zendesk token is require for making calls to its API. A Zendesk admin can generate one if needed.
 ZENDESK_TOKEN='token'
+
+# Username (usually an email address) of the account to which the token belongs.
 ZENDESK_USERNAME='example@example.com
+
+# ID of the group in Zendesk to which a newly created ticket will be assigned.
+ZENDESK_NEW_TICKET_GROUP_ID='123'

--- a/README.md
+++ b/README.md
@@ -8,19 +8,35 @@ Once you’ve cloned this then `bundle` will install the requirements.
 
 ## Running the application
 
-Prepare the application configuration:
+The application makes use of environment variables for specifying certain configurable parameters.
+You can set these by creating a file named `.env` and defining any environment variables within. 
+The file `.env-example` lists all the required environment variables with example values - simply 
+copy it and change the values.
 
-```
+```bash
 cp .env-example .env
 vim .env
 ```
 
-You can run the application with:
+Once the required environment variables have been defined, you can run the application with:
 
-```
+```bash
 bundle exec rails server
 open localhost:3000
 ```
+
+#### Environment variables
+
+| Variable name | Description |
+| ------------- | ----------- |
+| `ZENDESK_BASE_URL` | Base URL of Zendesk API (e.g. https://<your-org>.zendesk.com/api/v2/) |
+| `ZENDESK_TOKEN` | Zendesk token is require for making calls to its API. A Zendesk admin can 
+generate one if needed. |
+| `ZENDESK_USERNAME` | Username (usually an email address) of the account to which the token 
+belongs. |
+| `ZENDESK_NEW_TICKET_GROUP_ID` | ID of the group in Zendesk to which a newly created ticket will
+be assigned. |
+
 
 ## Running the tests
 

--- a/app/models/onboarding_form_service.rb
+++ b/app/models/onboarding_form_service.rb
@@ -33,17 +33,13 @@ class OnboardingFormService
       ]
     end
 
-    def find_group_id()
-      ZENDESK_CLIENT.search({:query => "type:group name:'#{ZENDESK_GROUP_NAME}'"}).fetch.first.id
-    end
-
     def generate_ticket_body(onboarding_form)
       {
           requester: {
               name: value_or_default(onboarding_form.contact_details_name),
               email: value_or_default(onboarding_form.contact_details_email)
           },
-          group_id: find_group_id(),
+          group_id: ZENDESK_GROUP_ID,
           subject: "[GOV.UK Verify] #{value_or_default(onboarding_form.service_display_name)}: #{value_or_default(onboarding_form.environment_access)} [requestor: #{value_or_default(onboarding_form.contact_details_name)}]",
           comment: {
               body: <<~EOF

--- a/config/initializers/zendesk_client.rb
+++ b/config/initializers/zendesk_client.rb
@@ -6,4 +6,4 @@ ZENDESK_CLIENT = ZendeskAPI::Client.new do |config|
   config.token = ENV.fetch('ZENDESK_TOKEN')
 end
 
-ZENDESK_GROUP_NAME = '3rd Line - Product Support (all teams)'
+ZENDESK_GROUP_ID = ENV.fetch('ZENDESK_NEW_TICKET_GROUP_ID')

--- a/spec/features/user_visits_form_spec.rb
+++ b/spec/features/user_visits_form_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe 'The start page', :type => :feature do
 
   ZENDESK_TICKETS_URL = "#{ENV.fetch('ZENDESK_BASE_URL')}tickets"
   ZENDESK_UPLOADS_URL = "#{ENV.fetch('ZENDESK_BASE_URL')}uploads"
-  ZENDESK_SEARCH_URL = "#{ENV.fetch('ZENDESK_BASE_URL')}search?query=type:group name:'#{ZENDESK_GROUP_NAME}'"
 
   before(:all) do
     @cert_file = Tempfile.new('good-cert')
@@ -54,10 +53,6 @@ RSpec.describe 'The start page', :type => :feature do
     stub_request(:post, ZENDESK_TICKETS_URL).to_return(:status => 201, :body => {"ticket":{"id":ticket_number}}.to_json, :headers => { "Content-Type": "application/json" })
     stub_request(:post, ZENDESK_UPLOADS_URL).to_return(:status => 201, :body => {"upload":{"token":ticket_number}}.to_json, :headers => { "Content-Type": "text/plain" })
     stub_request(:put, "#{ZENDESK_TICKETS_URL}/#{ticket_number}").to_return(:status => 200, :body => {"ticket":{"id":ticket_number}}.to_json, :headers => { "Content-Type": "application/json" })
-
-    stub_request(:get, ZENDESK_SEARCH_URL).to_return(:status => 200,
-                                                     :body => {"results": [{"id":360000257114 }]}.to_json,
-                                                     :headers => { "Content-Type": "application/json" })
 
     submit_valid_form
     expect(page).to have_content('Your ticket has been created with the id #123456')

--- a/spec/models/onboarding_form_service_spec.rb
+++ b/spec/models/onboarding_form_service_spec.rb
@@ -41,10 +41,7 @@ describe OnboardingFormService do
 
   context 'prepare the zendesk ticket' do
     it 'should generate a valid zendesk ticket' do
-      json = {"results": [{ "name": "Connecting to Verify", "created_at":  "2009-05-13T00:07:08Z", "updated_at": "2011-07-22T00:11:12Z", "id": 360000257114, "result_type": "group", "url": "http://example.com" }], "count": 1}.to_json
-      stub_request(:get, "https://example.com/api/v2/search?query=type:group%20name:'Connecting%20to%20Verify'")
-          .with(:headers => {'Accept'=>'application/json'})
-          .to_return(:status => 200, :body => json, :headers => { :content_type => "application/json", :content_length => json.size })
+      stub_const('ZENDESK_GROUP_ID', 360000257114)
 
       form = create_valid_form
 
@@ -139,10 +136,7 @@ describe OnboardingFormService do
     end
 
     it 'should generate an empty zendesk ticket' do
-      json = {"results": [{ "name": "Connecting to Verify", "created_at":  "2009-05-13T00:07:08Z", "updated_at": "2011-07-22T00:11:12Z", "id": 360000257114, "result_type": "group", "url": "http://example.com" }], "count": 1}.to_json
-      stub_request(:get, "https://example.com/api/v2/search?query=type:group%20name:'Connecting%20to%20Verify'")
-          .with(:headers => {'Accept'=>'application/json'})
-          .to_return(:status => 200, :body => json, :headers => { :content_type => "application/json", :content_length => json.size })
+      stub_const('ZENDESK_GROUP_ID', 360000257114)
 
       form = OnboardingForm.new({
         environment_access: '',

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,6 +2,7 @@ ENV['RAILS_ENV'] ||= 'test'
 ENV['ZENDESK_BASE_URL'] = 'https://example.com/api/v2/'
 ENV['ZENDESK_TOKEN'] = 'some-token'
 ENV['ZENDESK_USERNAME'] = 'idasupport@example.com'
+ENV['ZENDESK_NEW_TICKET_GROUP_ID'] = '1234'
 require File.expand_path('../../config/environment', __FILE__)
 
 abort('The Rails environment is running in production mode!') if Rails.env.production?


### PR DESCRIPTION
This puts back in the changes originally done in PR#29. We also add the envar ZENDESK_NEW_TICKET_GROUP_ID to the rails helper as this is required by the tests.

https://trello.com/c/EhzSC1vv/366-zendesk-migration-configure-rp-form