### PR TITLE
Update README.md to mark repo as archived

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 A form for requesting configuration changes for integrating a Relying Party to GOV.UK Verify.
 
+>**GOV.UK Verify has closed**
+>
+>This repository is out of date and has been archived
+
+
 ## Installing the application
 
 Once you’ve cloned this then `bundle` will install the requirements.


### PR DESCRIPTION
As agreed in [verify-architecture ADR 0039](https://github.com/alphagov/verify-architecture/blob/master/adr/0039-use-prs-before-archiving-repos.md), a PR must be approved by all engineers on the team before being archived.

Approving this PR indicates approval for this repo to be archived.